### PR TITLE
Use target and prerequisite in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: docs
-
 help:
 	@echo "available commands"
 	@echo " - install    : installs all requirements"
@@ -27,5 +25,5 @@ flake:
 
 check: flake test clean
 
-docs:
-	pdoc --html --force --output-dir docs common
+docs: common.py
+	pdoc --html --force --output-dir $@ $?


### PR DESCRIPTION
so docs (the target) is only rebuilt if common.py (the prequisite) was updated after the last make.

Hi @koaning. I'm loving your https://calmcode.io/ videos, and found a place were I could maybe contribute after watching https://calmcode.io/makefiles/phony-folders.html.

The docs target in your Makefile is maybe one of the only targets that should not be a [phony one](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html), since it's one that is generating a folder which has the same name as the target. Instead, you can tell make that you're building docs from common.py, and then it will only rebuild docs if common.py was updated, which might be much more powerful, and closer to what make was built for. I'm using [automatic variables](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html) to refer to the target and the prerequisites.

Just something that I thought might be nice to show in an introductory series of videos on make.